### PR TITLE
New tacks for governors and scouting

### DIFF
--- a/maptacks.lua
+++ b/maptacks.lua
@@ -51,20 +51,20 @@ local g_buildOps = {
 	GameInfo.UnitOperations.UNITOPERATION_REMOVE_FEATURE,
 	GameInfo.UnitOperations.UNITOPERATION_HARVEST_RESOURCE,
 };
-local g_repairOps = {
+local g_miscIcons = {
+	GameInfo.UnitOperations.UNITOPERATION_BUILD_ROUTE,
 	GameInfo.UnitOperations.UNITOPERATION_CLEAR_CONTAMINATION,
 	GameInfo.UnitOperations.UNITOPERATION_REPAIR,
-};
-local g_miscOps = {
-	GameInfo.UnitOperations.UNITOPERATION_BUILD_ROUTE,
 	GameInfo.UnitOperations.UNITOPERATION_DESIGNATE_PARK,
 	GameInfo.UnitOperations.UNITOPERATION_EXCAVATE,
 	GameInfo.UnitOperations.UNITOPERATION_MAKE_TRADE_ROUTE,
+	GameInfo.Units.UNIT_SPY,
+	GameInfo.Notifications.NOTIFICATION_BARBARIANS_SIGHTED,
+	GameInfo.Notifications.NOTIFICATION_DISCOVER_GOODY_HUT,
 	GameInfo.UnitOperations.UNITOPERATION_WMD_STRIKE,
 	GameInfo.UnitOperations.UNITOPERATION_PILLAGE,
-	GameInfo.UnitCommands.UNITCOMMAND_PLUNDER_TRADE_ROUTE,
+	-- GameInfo.UnitCommands.UNITCOMMAND_PLUNDER_TRADE_ROUTE,
 	GameInfo.UnitCommands.UNITCOMMAND_FORM_ARMY,
-	GameInfo.Units.UNIT_SPY,
 	GameInfo.UnitCommands.UNITCOMMAND_ACTIVATE_GREAT_PERSON,
 };
 
@@ -124,8 +124,9 @@ function MapTacksIconOptions(stockIcons : table)
 	-- Improvements
 	local builderIcons = {};
 	local uniqueIcons = {};
+	local governorIcons = {};
 	local minorCivIcons = {};
-	local miscIcons = {};
+	local engineerIcons = {};
 	for item in GameInfo.Improvements() do
 		-- does this improvement have a valid build unit?
 		local valid = item.ValidBuildUnits[1];
@@ -139,28 +140,32 @@ function MapTacksIconOptions(stockIcons : table)
 				if traits[trait] then
 					-- separate unique improvements
 					table.insert(uniqueIcons, entry);
+				elseif nil then  -- TODO: find governors
+					table.insert(governorIcons, entry);
 				elseif trait:sub(1, 10) == "MINOR_CIV_" then
 					table.insert(minorCivIcons, entry);
+				else  -- TODO: find governors
+					print(trait)
 				end
 			elseif unit.UnitType == "UNIT_BUILDER" then
 				table.insert(builderIcons, entry);
 			else
-				table.insert(miscIcons, entry);
+				table.insert(engineerIcons, entry);
 			end
 		end
 	end
 
-	if #uniqueIcons==0 then
+	if #uniqueIcons == 0 then
 		table.insert(icons, MapTacksIcon(
 			GameInfo.UnitOperations.UNITOPERATION_BUILD_IMPROVEMENT))
 	end
 	for i,v in ipairs(uniqueIcons) do table.insert(icons, v); end
 	for i,v in ipairs(builderIcons) do table.insert(icons, v); end
 	for i,v in ipairs(g_buildOps) do table.insert(icons, MapTacksIcon(v)); end
+	for i,v in ipairs(governorIcons) do table.insert(icons, v); end
 	for i,v in ipairs(minorCivIcons) do table.insert(icons, v); end
-	for i,v in ipairs(g_repairOps) do table.insert(icons, MapTacksIcon(v)); end
-	for i,v in ipairs(miscIcons) do table.insert(icons, v); end
-	for i,v in ipairs(g_miscOps) do table.insert(icons, MapTacksIcon(v)); end
+	for i,v in ipairs(engineerIcons) do table.insert(icons, v); end
+	for i,v in ipairs(g_miscIcons) do table.insert(icons, MapTacksIcon(v)); end
 
 	-- Great people
 	for item in GameInfo.GreatPersonClasses() do
@@ -181,18 +186,22 @@ function MapTacksIcon(item)
 	elseif item.DistrictType then
 		name = "ICON_"..item.DistrictType;
 		tooltip = item.DistrictType;
-		if tooltip=="DISTRICT_WONDER" then
+		if tooltip == "DISTRICT_WONDER" then
 			tooltip = "LOC_CIVICS_KEY_WONDER";
 		end
 	elseif item.ImprovementType then
 		name = item.Icon;
 		tooltip = item.ImprovementType;
+	elseif item.NotificationType then
+		-- TODO: verify
+		name = item.Icon;
+		tooltip = item.NotificationType;
 	elseif item.UnitType == "UNIT_SPY" then
-		name="ICON_UNITOPERATION_SPY_COUNTERSPY_ACTION";
-		tooltip=item.Name;
+		name = "ICON_UNITOPERATION_SPY_COUNTERSPY_ACTION";
+		tooltip = item.Name;
 	elseif item.UnitType then
 		name = "ICON_"..item.UnitType;
-		tooltip=item.Name;
+		tooltip = item.Name;
 	else
 		name = item.Icon;
 		tooltip = item.Description;
@@ -216,6 +225,8 @@ function MapTacksType(pin : table)
 	elseif iconType == "UNIT_" then
 		return MAPTACKS_WHITE;
 	elseif iconType == "DISTR" then
+		return MAPTACKS_COLOR;
+	elseif iconType == "BUILD" then  -- wonders
 		return MAPTACKS_COLOR;
 	else
 		return MAPTACKS_GRAY;


### PR DESCRIPTION
Resolves #35: governor improvements.
Resolves #36: scouting markers.
Resolves #26: styling for buildings, wonders, and notification icons.
Adds a switch for #19: wonder support (but with the switch turned off).