### PR TITLE
Localization for mod name & description

### DIFF
--- a/maptacks-text.xml
+++ b/maptacks-text.xml
@@ -1,32 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
   <LocalizedText>
+    <Replace Tag="LOC_MAP_PIN_POPUP_TITLE" Language="en_US">
+      <Text>Edit Map Tack</Text>
+    </Replace>
+    <Replace Tag="LOC_MAP_PIN_SEND_TO_CHAT_TT" Language="en_US">
+      <Text>Add this map tack to your chat text.</Text>
+    </Replace>
+    <Replace Tag="LOC_MAP_PIN_SEND_TO_CHAT_NOT_VISIBLE_TT" Language="en_US">
+      <Text>The map tack is not visible to the current chat target.</Text>
+    </Replace>
     <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="en_US">
       <Text>Map Tacks</Text>
-    </Row>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="de_DE">
-      <Text>Landkarte Pinnadeln</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="es_ES">
-      <Text>chinchetas de mapa</Text>
+    <Replace Tag="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" Language="en_US">
+      <Text>Map Tacks</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="fr_FR">
-      <Text>épingles de carte</Text>
+    <Replace Tag="LOC_HUD_MAP_PLACE_MAP_PIN" Language="en_US">
+      <Text>Add Tack</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="it_IT">
-      <Text>puntine della mappa</Text>
+    <Replace Tag="LOC_HUD_MAP_PLACE_MAP_PIN_TT" Language="en_US">
+      <Text>Click on a hex to place a map tack at that location.</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="ko_KR">
-      <Text>지도 압정 (TODO)</Text>
+    <Replace Tag="LOC_MAP_PIN_DEFAULT_NAME" Language="en_US">
+      <Text>Unnamed Location {1_number}</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="pl_PL">
-      <Text>szpilki mapy</Text>
+    <Replace Tag="LOC_MAP_PIN_LIST_PLAYER_PIN_TOOLTIP" Language="en_US">
+      <Text>Left click to find the tack on the map.  Right click to edit.</Text>
     </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="ru_RU">
-      <Text>булавки карты</Text>
-    </Replace>
-    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="zh_Hans_CN">
-      <Text>地图大头钉 (TODO)</Text>
+    <Replace Tag="LOC_MAP_PIN_LIST_REMOTE_PIN_TOOLTIP" Language="en_US">
+      <Text>Left click to find the tack on the map.</Text>
     </Replace>
   </LocalizedText>
 </GameData>

--- a/maptacks-text.xml
+++ b/maptacks-text.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+  <LocalizedText>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="en_US">
+      <Text>Map Tacks</Text>
+    </Row>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="de_DE">
+      <Text>Landkarte Pinnadeln</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="es_ES">
+      <Text>chinchetas de mapa</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="fr_FR">
+      <Text>épingles de carte</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="it_IT">
+      <Text>puntine della mappa</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="ko_KR">
+      <Text>지도 압정 (TODO)</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="pl_PL">
+      <Text>szpilki mapy</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="ru_RU">
+      <Text>булавки карты</Text>
+    </Replace>
+    <Replace Tag="LOC_HUD_MAP_PIN_LIST" Language="zh_Hans_CN">
+      <Text>地图大头钉 (TODO)</Text>
+    </Replace>
+  </LocalizedText>
+</GameData>

--- a/maptacks.modinfo
+++ b/maptacks.modinfo
@@ -10,14 +10,18 @@
   <LocalizedText>
     <Text id="MAP_TACKS_DESCRIPTION">
       <en_US>Improve the user interface for map pins.</en_US>
-      <de_DE>Verbessere die Benutzerschnittstelle für Landkarte Pinnadeln.</de_DE>
-      <es_ES>Mejore la interfaz de usuario para chinchetas de mapa.</es_ES>
-      <fr_FR>Améliorer l'interface utilisateur pour les épingles de carte.</fr_FR>
-      <it_IT>Migliora l'interfaccia utente per i puntine della mappa.</it_IT>
-      <!-- <ko_KR>TODO</ko_KR> -->
-      <pl_PL>Ulepsz interfejs użytkownika dla szpilki mapy.</pl_PL>
-      <ru_RU>Улучшите интерфейс пользователя для булавки карты.</ru_RU>
-      <!-- <zh_Hans_CN>TODO</zh_Hans_CN> -->
+      <de_DE>Verbessere die Benutzerschnittstelle für Landkartennadeln.</de_DE>
+      <es_ES>Mejore la interfaz de usuario para los marcadores del mapa.</es_ES>
+      <fr_FR>Améliorer l'interface utilisateur pour les marqueurs.</fr_FR>
+      <it_IT>Migliora l'interfaccia utente per i spilli mappa.</it_IT>
+      <pl_PL>Ulepsz interfejs użytkownika dla znaczniki na mapie.</pl_PL>
+      <pt_BR>Melhore a interface do usuário para os marcadores de mapa.</pt_BR>
+      <ru_RU>Улучшите интерфейс пользователя для отметки на карте.</ru_RU>
+      <!-- borrow the in-game localization for map pins -->
+      <ja_JP>LOC_HUD_MAP_PIN_LIST</ja_JP>
+      <ko_KR>LOC_HUD_MAP_PIN_LIST</ko_KR>
+      <zh_Hans_CN>LOC_HUD_MAP_PIN_LIST</zh_Hans_CN>
+      <zh_Hant_HK>LOC_HUD_MAP_PIN_LIST</zh_Hant_HK>
     </Text>
   </LocalizedText>
   <InGameActions>

--- a/maptacks.modinfo
+++ b/maptacks.modinfo
@@ -2,11 +2,24 @@
 <Mod id="0a1c826c-0f43-4876-b096-23e1292eee3c" version="0.9.2">
   <Properties>
     <Name>Map Tacks</Name>
-    <Description>Map pin improvements</Description>
-    <Teaser>Map pin improvements</Teaser>
+    <Description>MAP_TACKS_DESCRIPTION</Description>
+    <Teaser>MAP_TACKS_DESCRIPTION</Teaser>
     <Authors>Bradd Szonye</Authors>
     <AffectsSavedGames>0</AffectsSavedGames>
   </Properties>
+  <LocalizedText>
+    <Text id="MAP_TACKS_DESCRIPTION">
+      <en_US>Improve the user interface for map pins.</en_US>
+      <de_DE>Verbessere die Benutzerschnittstelle für Landkarte Pinnadeln.</de_DE>
+      <es_ES>Mejore la interfaz de usuario para chinchetas de mapa.</es_ES>
+      <fr_FR>Améliorer l'interface utilisateur pour les épingles de carte.</fr_FR>
+      <it_IT>Migliora l'interfaccia utente per i puntine della mappa.</it_IT>
+      <!-- <ko_KR>TODO</ko_KR> -->
+      <pl_PL>Ulepsz interfejs użytkownika dla szpilki mapy.</pl_PL>
+      <ru_RU>Улучшите интерфейс пользователя для булавки карты.</ru_RU>
+      <!-- <zh_Hans_CN>TODO</zh_Hans_CN> -->
+    </Text>
+  </LocalizedText>
   <InGameActions>
     <ImportFiles id="MAPTACKS_FILES">
       <Properties>
@@ -20,6 +33,9 @@
       <File>mappinpopup.xml</File>
       <File>maptacks.lua</File>
     </ImportFiles>
+    <UpdateText id="MAPTACKS_TEXT">
+      <File>maptacks-text.xml</File>
+    </UpdateText>
   </InGameActions>
   <Files>
     <File>mappinlistpanel.lua</File>
@@ -29,5 +45,6 @@
     <File>mappinpopup.lua</File>
     <File>mappinpopup.xml</File>
     <File>maptacks.lua</File>
+    <File>maptacks-text.xml</File>
   </Files>
 </Mod>


### PR DESCRIPTION
Use the Map Tacks name in the user interface instead of Map Pins. Resolves #17.
Localize the mod description.